### PR TITLE
Add Vitest tests for objectToSearchParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
         "dev": "next dev --turbopack",
         "build": "next build",
         "start": "next start",
-        "lint": "next lint"
+        "lint": "next lint",
+        "test": "vitest"
     },
     "dependencies": {
         "@hookform/resolvers": "^5.0.1",
@@ -41,6 +42,7 @@
         "prettier-plugin-tailwindcss": "^0.6.11",
         "tailwindcss": "^4",
         "typescript": "^5",
-        "typescript-eslint": "^8.26.1"
+        "typescript-eslint": "^8.26.1",
+        "vitest": "^1.6.0"
     }
 }

--- a/src/shared/lib/utils.test.ts
+++ b/src/shared/lib/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { objectToSearchParams } from './utils';
+
+describe('objectToSearchParams', () => {
+  it('converts a simple object to search params', () => {
+    const result = objectToSearchParams({ a: 1, b: 'test' });
+    expect(result.toString()).toBe('a=1&b=test');
+  });
+
+  it('ignores keys with undefined values', () => {
+    const result = objectToSearchParams({ a: 1, b: undefined, c: 'test' });
+    expect(result.toString()).toBe('a=1&c=test');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
## Summary
- configure Vitest
- add npm script for running tests
- test `objectToSearchParams` to ensure it converts objects and ignores undefined values

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68402d73b3e4832ab1d84dc6eb44d690